### PR TITLE
remove build options from zin dependency

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -308,10 +308,7 @@ pub fn build(b: *std.Build) void {
 
     // Build the video play example.
     {
-        const zin = b.dependency("zin", .{
-            .optimize = optimize,
-            .target = target,
-        }).module("zin");
+        const zin = b.dependency("zin", .{}).module("zin");
 
         const video_play = b.addExecutable(.{
             .name = "video-play",


### PR DESCRIPTION
Since zin is just a zig module, we don't need to specify a target/optimize mode. This allows the same module to be imported into other compilation units even if they are different targets/optimize modes.