### PR TITLE
Simplifies initialization of logger

### DIFF
--- a/src/examples/audio_src.zig
+++ b/src/examples/audio_src.zig
@@ -37,11 +37,7 @@ const global = struct {
 
 pub fn main() !void {
     // If we're linking with the Zig module, set up logging.
-    var logger = if (example_options.use_zig_module) pw.Logger.init() else {};
-    if (example_options.use_zig_module) {
-        pw.c.pw_log_set(&logger);
-        pw.c.pw_log_set_level(pw.Logger.default_level);
-    }
+    if (example_options.use_zig_module) pw.Logger.init();
 
     // Configure our runtime log level
     const log_level_env_var = "AUDIO_SRC_LOG_LEVEL";

--- a/src/examples/video_play.zig
+++ b/src/examples/video_play.zig
@@ -84,11 +84,7 @@ const global = struct {
 
 pub fn main() !void {
     // If we're linking with the Zig module, set up logging.
-    var logger = if (example_options.use_zig_module) pw.Logger.init() else {};
-    if (example_options.use_zig_module) {
-        pw.c.pw_log_set(&logger);
-        pw.c.pw_log_set_level(pw.Logger.default_level);
-    }
+    if (example_options.use_zig_module) pw.Logger.init();
 
     // Configure our runtime log level
     const log_level_env_var = "VIDEO_PLAY_LOG_LEVEL";


### PR DESCRIPTION
It's convenient to make the logger a global since it needs to survive the lifetime of the program. However, unless we're targeting the x64 backend, extern references can't be resolved at comptime. This PR works around this by making the logger a singleton, and also adds an init helper to make it easier to use.